### PR TITLE
Allow null events in propType validation

### DIFF
--- a/src/ChildBridge.js
+++ b/src/ChildBridge.js
@@ -6,7 +6,7 @@ class ChildBridge extends React.Component {
     events: PropTypes.oneOfType([
       PropTypes.array,
       PropTypes.string
-    ]).isRequired,
+    ]),
     onEvent: PropTypes.func.isRequired,
     inject: PropTypes.func.isRequired
   }
@@ -27,7 +27,11 @@ class ChildBridge extends React.Component {
 
   events(child){
     let { events, onEvent } = this.props;
-    events = events == null ? [] : [].concat(events);
+    if (events == null) {
+      return null
+    }
+
+    events = [].concat(events);
 
     return events.reduce((map, event) => {
       map[event] = onEvent.bind(this, event, child.props[event])


### PR DESCRIPTION
Already supported by https://github.com/jquense/topeka/blob/v0.3.1/src/ChildBridge.js#L30.

This lets me do

```js
<MessageTrigger
  for={name}
  events={null}
  inject={this.inject}
>
```

without having to do an ugly `events={[]}` or something.