### PR TITLE
use the prop-types package as accessing PropTypes via the main React package is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lolex": "^1.4.0",
     "marked": "^0.3.5",
     "mocha": "^2.3.3",
+    "prop-types": "^15.5.0",
     "raw-loader": "^0.5.1",
     "react": "^15.0.1",
     "react-bootstrap": "^0.29.2",
@@ -73,7 +74,7 @@
     "webpack-dev-server": "^1.12.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.9 || >=15.3.0"
   },
   "dependencies": {
     "chain-function": "^1.0.0",

--- a/src/Binding.js
+++ b/src/Binding.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Bridge from './ChildBridge'
 
 function extractTargetValue(arg) {

--- a/src/BindingContext.js
+++ b/src/BindingContext.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import uncontrollable from 'uncontrollable';
 import invariant from 'invariant';
 import updateIn from './updateIn';
@@ -16,7 +17,7 @@ class BindingContext extends React.Component {
      * BindingContext assumes that `value` is immutable so you must provide a _new_ value
      * object to trigger an update. The `<Binding/>` components do this by default.
      */
-    value: React.PropTypes.object,
+    value: PropTypes.object,
 
     /**
      * Callback that is called when the `value` prop changes.
@@ -28,7 +29,7 @@ class BindingContext extends React.Component {
      * )
      * ```
      */
-    onChange: React.PropTypes.func,
+    onChange: PropTypes.func,
 
     /**
      * A function used to extract value paths from the Context value.
@@ -42,7 +43,7 @@ class BindingContext extends React.Component {
      * ) -> object
      * ```
      */
-    getter: React.PropTypes.func,
+    getter: PropTypes.func,
 
     /**
      * A value setter function. `setter` is called with `path`, the context `value` and the path `value`.
@@ -56,11 +57,11 @@ class BindingContext extends React.Component {
      * ) -> object
      * ```
      */
-    setter: React.PropTypes.func
+    setter: PropTypes.func
   }
 
   static childContextTypes = {
-    registerWithBindingContext: React.PropTypes.func
+    registerWithBindingContext: PropTypes.func
   }
 
   static defaultProps = {

--- a/src/ChildBridge.js
+++ b/src/ChildBridge.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class ChildBridge extends React.Component {
 


### PR DESCRIPTION
Due to `prop-types`  [compatibility](https://www.npmjs.com/package/prop-types#compatibility) I have had to update the react peer dependency from `"^0.14.0 || ^15.0.0"` to `"^0.14.9 || >=15.3.0"`

More info about this change can be found at `prop-types` [readme](https://www.npmjs.com/package/prop-types#how-to-depend-on-this-package)

Closes: https://github.com/jquense/topeka/issues/4 